### PR TITLE
Back buttons

### DIFF
--- a/app/src/main/java/com/example/final_project/AdminActivity.java
+++ b/app/src/main/java/com/example/final_project/AdminActivity.java
@@ -18,6 +18,12 @@ public class AdminActivity extends AppCompatActivity {
         binding = ActivityAdminBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
+        //adds back button to action bar
+        setSupportActionBar(binding.adminToolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+
         binding.manageUsersButton.setOnClickListener(v -> {
             Intent intent = ManageUsersActivity.manageUsersIntentFactory(getApplicationContext());
             startActivity(intent);
@@ -33,6 +39,15 @@ public class AdminActivity extends AppCompatActivity {
             startActivity(intent);
         });
 
+    }
+
+    // opens LoginActivity when back button is pressed
+    @Override
+    public boolean onSupportNavigateUp() {
+        Intent intent = new Intent(this, LoginActivity.class);
+        startActivity(intent);
+        finish();
+        return true;
     }
 
     static Intent adminIntentFactory(Context context) {

--- a/app/src/main/java/com/example/final_project/AdminThingsActivity.java
+++ b/app/src/main/java/com/example/final_project/AdminThingsActivity.java
@@ -19,10 +19,24 @@ public class AdminThingsActivity extends AppCompatActivity {
         binding = ActivityAdminThingsBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
+        //adds back button to action bar
+        setSupportActionBar(binding.adminThingsToolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+
+
         // Set up the UI components and listeners for managing users
         // RecyclerView, buttons, etc. can be initialized here
     }
 
+    @Override
+    public boolean onSupportNavigateUp() {
+        Intent intent = new Intent(this, AdminActivity.class);
+        startActivity(intent);
+        finish();
+        return true;
+    }
     static Intent adminThingsIntentFactory(Context context) {
         return new Intent(context, AdminThingsActivity.class);
     }

--- a/app/src/main/java/com/example/final_project/LoginActivity.java
+++ b/app/src/main/java/com/example/final_project/LoginActivity.java
@@ -3,6 +3,8 @@ package com.example.final_project;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
@@ -26,6 +28,9 @@ public class LoginActivity extends AppCompatActivity {
         binding = ActivityLoginBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
+        setSupportActionBar(binding.loginToolbar);
+        getSupportActionBar().setDisplayShowTitleEnabled(false);
+
         binding.loginButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -43,6 +48,23 @@ public class LoginActivity extends AppCompatActivity {
         });
     }
 
+    //LOGOUT MENU
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.logout_menu, menu);
+        return true;
+    }
+
+    // Handle logout action
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == R.id.action_logout) {
+            Toast.makeText(this, "Logout clicked", Toast.LENGTH_SHORT).show();
+            finishAffinity(); // or redirect to LoginActivity if needed
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
     static Intent loginIntentFactory(Context context) {
         Intent intent = new Intent(context, LoginActivity.class);
         return intent;

--- a/app/src/main/java/com/example/final_project/MainActivity.java
+++ b/app/src/main/java/com/example/final_project/MainActivity.java
@@ -34,6 +34,13 @@ public class MainActivity extends AppCompatActivity {
         binding = ActivityMainBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
+        //adds back button to action bar
+        setSupportActionBar(binding.mainActivityToolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+
+
         // TODO: get movies from db
         // dummy values for now
         CompletedWatchListItem item2 = new CompletedWatchListItem("title", "genre", "5/5");
@@ -81,7 +88,14 @@ public class MainActivity extends AppCompatActivity {
         }).start();
     }
 
-
+    // opens LoginActivity when back button is pressed
+    @Override
+    public boolean onSupportNavigateUp() {
+        Intent intent = new Intent(this, LoginActivity.class);
+        startActivity(intent);
+        finish();
+        return true;
+    }
 
     public static Intent mainIntentFactory(Context context, String username) {
         Intent intent = new Intent(context, MainActivity.class);

--- a/app/src/main/java/com/example/final_project/MainActivity.java
+++ b/app/src/main/java/com/example/final_project/MainActivity.java
@@ -67,13 +67,9 @@ public class MainActivity extends AppCompatActivity {
         recyclerView.setAdapter(watchListAdapter);
 
         String username = getIntent().getStringExtra(MAIN_ACTIVITY_USERNAME_KEY);
-        if (username != null && !username.isEmpty()) {
-            //binding.welcomeTextView.setText("Welcome, " + username + "!");
-
-            if (username.equalsIgnoreCase("admin")) {
-                Intent intent = AdminActivity.adminIntentFactory(getApplicationContext());
-                startActivity(intent);
-            }
+        if (username != null && username.toLowerCase().contains("admin")) {
+            Intent intent = AdminActivity.adminIntentFactory(getApplicationContext());
+            startActivity(intent);
         }
 
         //Temporary code to add a movie to the watchlist database

--- a/app/src/main/java/com/example/final_project/ManageGenresActivity.java
+++ b/app/src/main/java/com/example/final_project/ManageGenresActivity.java
@@ -19,8 +19,24 @@ public class ManageGenresActivity extends AppCompatActivity {
         binding = ActivityManageGenresBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
+        //adds back button to action bar
+        setSupportActionBar(binding.genresToolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+
+
         // Set up the UI components and listeners for managing users
         // RecyclerView, buttons, etc. can be initialized here
+    }
+
+    // opens LoginActivity when back button is pressed
+    @Override
+    public boolean onSupportNavigateUp() {
+        Intent intent = new Intent(this, AdminActivity.class);
+        startActivity(intent);
+        finish();
+        return true;
     }
 
     static Intent manageGenresIntentFactory(Context context) {

--- a/app/src/main/java/com/example/final_project/ManageUsersActivity.java
+++ b/app/src/main/java/com/example/final_project/ManageUsersActivity.java
@@ -19,10 +19,23 @@ public class ManageUsersActivity extends AppCompatActivity {
         binding = ActivityManageUsersBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
+        //adds back button to action bar
+        setSupportActionBar(binding.usersToolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+
         // Set up the UI components and listeners for managing users
         // RecyclerView, buttons, etc. can be initialized here
     }
 
+    @Override
+    public boolean onSupportNavigateUp() {
+        Intent intent = new Intent(this, AdminActivity.class);
+        startActivity(intent);
+        finish();
+        return true;
+    }
     static Intent manageUsersIntentFactory(Context context) {
         return new Intent(context, ManageUsersActivity.class);
     }

--- a/app/src/main/java/com/example/final_project/SignUpActivity.java
+++ b/app/src/main/java/com/example/final_project/SignUpActivity.java
@@ -9,12 +9,14 @@ import android.widget.EditText;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
+import com.example.final_project.databinding.ActivitySignupBinding;
 
 
 public class SignUpActivity extends AppCompatActivity {
     private EditText usernameEditText;
     private EditText passwordEditText;
     private EditText confirmPasswordEditText;
+    private ActivitySignupBinding binding;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -24,6 +26,13 @@ public class SignUpActivity extends AppCompatActivity {
         passwordEditText = findViewById(R.id.newPasswordEditText);
         confirmPasswordEditText = findViewById(R.id.confirmPasswordEditText);
         Button signUpButton = findViewById(R.id.signUpButton);
+
+        //adds back button to action bar
+        setSupportActionBar(binding.signUpToolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+
 
         signUpButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -59,6 +68,15 @@ public class SignUpActivity extends AppCompatActivity {
 
         Intent intent = new Intent(SignUpActivity.this, MainActivity.class);
         startActivity(intent);
+    }
+
+    // opens LoginActivity when back button is pressed
+    @Override
+    public boolean onSupportNavigateUp() {
+        Intent intent = new Intent(this, LoginActivity.class);
+        startActivity(intent);
+        finish();
+        return true;
     }
 
     static Intent signupIntentFactory(Context context) {

--- a/app/src/main/res/layout/activity_admin.xml
+++ b/app/src/main/res/layout/activity_admin.xml
@@ -54,8 +54,10 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:id="@+id/adminToolbar"
-        android:background="@color/black"
-        android:theme="@style/Theme.AppCompat.DayNight.DarkActionBar"
-        app:title="Admin" />
+        app:navigationIcon="?attr/homeAsUpIndicator"
+        android:background="#424242"
+        app:title="Back to Login"
+        app:titleTextColor="@color/white"
+        android:theme="@style/Theme.AppCompat.DayNight.DarkActionBar" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_admin.xml
+++ b/app/src/main/res/layout/activity_admin.xml
@@ -50,4 +50,12 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/manageGenresButton" />
 
+    <androidx.appcompat.widget.Toolbar
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/adminToolbar"
+        android:background="@color/black"
+        android:theme="@style/Theme.AppCompat.DayNight.DarkActionBar"
+        app:title="Admin" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_admin_things.xml
+++ b/app/src/main/res/layout/activity_admin_things.xml
@@ -21,4 +21,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <androidx.appcompat.widget.Toolbar
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/adminThingsToolbar"
+        app:navigationIcon="?attr/homeAsUpIndicator"
+        android:background="#424242"
+        app:title="Back to Admin Dashboard"
+        app:titleTextColor="@color/white"
+        android:theme="@style/Theme.AppCompat.DayNight.DarkActionBar" />
+
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -4,12 +4,22 @@
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/loginToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="#E5E5E5"
+        app:popupTheme="@style/Theme.AppCompat.Light"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
     <TextView
         android:id="@+id/titleLoginTextView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginLeft="16dp"
-        android:layout_marginTop="70dp"
+        android:layout_marginTop="16dp"
         android:layout_marginRight="16dp"
         android:gravity="center"
         android:text="@string/welcome_to_movie_watchlist"
@@ -18,7 +28,7 @@
         android:textStyle="bold"
         app:layout_constraintStart_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@+id/loginToolbar" />
 
     <TextView
         android:id="@+id/titleSignInTextView"

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -98,5 +98,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         android:backgroundTint="#FFAf52" />
 
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,6 +7,16 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
+    <androidx.appcompat.widget.Toolbar
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/mainActivityToolbar"
+        app:navigationIcon="?attr/homeAsUpIndicator"
+        android:background="#424242"
+        app:title="Back to Login"
+        app:titleTextColor="@color/white"
+        android:theme="@style/Theme.AppCompat.DayNight.DarkActionBar" />
+
     <TextView
         android:id="@+id/watchMoviesTextView"
         android:text="@string/movies_to_watch"
@@ -15,7 +25,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="40dp"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/mainActivityToolbar"
         app:layout_constraintStart_toStartOf="parent"
         />
 
@@ -23,7 +33,7 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/watchListRecyclerView"
         android:layout_width="0dp"
-        android:layout_height="250dp"
+        android:layout_height="200dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/watchMoviesTextView"
@@ -44,7 +54,7 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/completedWatchListRecyclerView"
         android:layout_width="0dp"
-        android:layout_height="225dp"
+        android:layout_height="200dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/completedMoviesTextView"

--- a/app/src/main/res/layout/activity_manage_genres.xml
+++ b/app/src/main/res/layout/activity_manage_genres.xml
@@ -21,4 +21,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <androidx.appcompat.widget.Toolbar
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/genresToolbar"
+        app:navigationIcon="?attr/homeAsUpIndicator"
+        android:background="#424242"
+        app:title="Back to Admin Dashboard"
+        app:titleTextColor="@color/white"
+        android:theme="@style/Theme.AppCompat.DayNight.DarkActionBar" />
+
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_manage_users.xml
+++ b/app/src/main/res/layout/activity_manage_users.xml
@@ -21,4 +21,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <androidx.appcompat.widget.Toolbar
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/usersToolbar"
+        app:navigationIcon="?attr/homeAsUpIndicator"
+        android:background="#424242"
+        app:title="Back to Admin Dashboard"
+        app:titleTextColor="@color/white"
+        android:theme="@style/Theme.AppCompat.DayNight.DarkActionBar" />
+
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_signup.xml
+++ b/app/src/main/res/layout/activity_signup.xml
@@ -11,7 +11,7 @@
         android:id="@+id/signUpToolbar"
         app:navigationIcon="?attr/homeAsUpIndicator"
         android:background="#424242"
-        app:title="Back to Admin Dashboard"
+        app:title="Back to Login"
         app:titleTextColor="@color/white"
         android:theme="@style/Theme.AppCompat.DayNight.DarkActionBar" />
 

--- a/app/src/main/res/layout/activity_signup.xml
+++ b/app/src/main/res/layout/activity_signup.xml
@@ -5,6 +5,16 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <androidx.appcompat.widget.Toolbar
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/signUpToolbar"
+        app:navigationIcon="?attr/homeAsUpIndicator"
+        android:background="#424242"
+        app:title="Back to Admin Dashboard"
+        app:titleTextColor="@color/white"
+        android:theme="@style/Theme.AppCompat.DayNight.DarkActionBar" />
+
     <TextView
         android:id="@+id/titleSignUpTextView"
         android:layout_width="match_parent"
@@ -15,7 +25,7 @@
         android:textSize="42sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/signUpToolbar"
         android:background="#1DA1F2"
         android:textColor="#ffffff"/>
 
@@ -71,7 +81,5 @@
         app:layout_constraintTop_toBottomOf="@id/confirmPasswordEditText"
         android:backgroundTint="#008000"
         />
-
-
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/logout_menu.xml
+++ b/app/src/main/res/menu/logout_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/action_logout"
+        android:title="LOGOUT"
+        android:orderInCategory="100"
+        android:showAsAction="always" />
+
+</menu>


### PR DESCRIPTION
## Description
[Issue](https://github.com/Katz100/Final-Project/issues/38)
- added back buttons to admin pages
- added back button to sign up page (can not test until sign up button works on the login page)
- added logout dialogue on sign in page

## Steps for reviewer
Launch App to open login screen
**Login Page:** 
- Tap the menu icon (three dots) in the upper right corner
- Make sure it closes the app
**Admin Pages:**
- Sign in as an admin and navigate to admin dashboard
- Open a subpage (e.g., genres, users)
- Pressing back button should bring you back to admin dashboard
**Main Activity (watchlist):**
- Sign in as regular user and navigate to main activity (watchlist)
- pressing back button should bring you have to login page
**Sign-Up Page:**
- _Currently not testable:_ sign-up button navigation from the login page is not yet functional. Once working, back button should work.

_Will create an issue to add logout button to each screen (instead of just the login page)_