### PR TITLE
Implemented Intent Factories for AdminActivity

### DIFF
--- a/app/src/main/java/com/example/final_project/LoginActivity.java
+++ b/app/src/main/java/com/example/final_project/LoginActivity.java
@@ -77,6 +77,11 @@ public class LoginActivity extends AppCompatActivity {
             return;
         }
 
+        if (username.toLowerCase().contains("admin")) {
+            Intent intent = AdminActivity.adminIntentFactory(getApplicationContext());
+            startActivity(intent);
+            return;
+        }
         // Here you would typically check the username and password against a database
         // For now, we will just simulate a successful login
 

--- a/app/src/main/java/com/example/final_project/MainActivity.java
+++ b/app/src/main/java/com/example/final_project/MainActivity.java
@@ -76,11 +76,11 @@ public class MainActivity extends AppCompatActivity {
         watchListAdapter = new WatchListAdapter(this, watchListItems);
         recyclerView.setAdapter(watchListAdapter);
 
-        String username = getIntent().getStringExtra(MAIN_ACTIVITY_USERNAME_KEY);
+        /*String username = getIntent().getStringExtra(MAIN_ACTIVITY_USERNAME_KEY);
         if (username != null && username.toLowerCase().contains("admin")) {
             Intent intent = AdminActivity.adminIntentFactory(getApplicationContext());
             startActivity(intent);
-        }
+        }*/
 
         //Changes the title in the Menu Bar to MovieWatchlist
         try {

--- a/app/src/main/java/com/example/final_project/MainActivity.java
+++ b/app/src/main/java/com/example/final_project/MainActivity.java
@@ -107,10 +107,11 @@ public class MainActivity extends AppCompatActivity {
         } else {
             Log.e("MainActivity", "Username extra was null!");
         }
-        if (username != null && username.toLowerCase().contains("admin")) {
+
+        /*if (username != null && username.toLowerCase().contains("admin")) {
             Intent intent = AdminActivity.adminIntentFactory(getApplicationContext());
             startActivity(intent);
-        }
+        }*/
 
         //Changes the title in the Menu Bar to MovieWatchlist
         try {

--- a/app/src/main/java/com/example/final_project/MainActivity.java
+++ b/app/src/main/java/com/example/final_project/MainActivity.java
@@ -76,11 +76,6 @@ public class MainActivity extends AppCompatActivity {
         watchListAdapter = new WatchListAdapter(this, watchListItems);
         recyclerView.setAdapter(watchListAdapter);
 
-        /*String username = getIntent().getStringExtra(MAIN_ACTIVITY_USERNAME_KEY);
-        if (username != null && username.toLowerCase().contains("admin")) {
-            Intent intent = AdminActivity.adminIntentFactory(getApplicationContext());
-            startActivity(intent);
-        }*/
 
         //Changes the title in the Menu Bar to MovieWatchlist
         try {

--- a/app/src/main/java/com/example/final_project/MainActivity.java
+++ b/app/src/main/java/com/example/final_project/MainActivity.java
@@ -76,6 +76,11 @@ public class MainActivity extends AppCompatActivity {
         watchListAdapter = new WatchListAdapter(this, watchListItems);
         recyclerView.setAdapter(watchListAdapter);
 
+        String username = getIntent().getStringExtra(MAIN_ACTIVITY_USERNAME_KEY);
+        if (username != null && username.toLowerCase().contains("admin")) {
+            Intent intent = AdminActivity.adminIntentFactory(getApplicationContext());
+            startActivity(intent);
+        }
 
         //Changes the title in the Menu Bar to MovieWatchlist
         try {

--- a/app/src/test/java/com/example/final_project/AdminActivityTest.java
+++ b/app/src/test/java/com/example/final_project/AdminActivityTest.java
@@ -1,0 +1,59 @@
+package com.example.final_project;
+
+import static org.robolectric.Shadows.shadowOf;
+
+import android.app.Activity;
+import android.content.Intent;
+
+import junit.framework.TestCase;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
+
+@RunWith(RobolectricTestRunner.class)
+public class AdminActivityTest extends TestCase {
+
+    @Test
+    public void testClickingManageUsers() {
+        try(ActivityController<AdminActivity> controller = Robolectric.buildActivity(AdminActivity.class)){
+            controller.setup();
+
+            AdminActivity activity = controller.get();
+            activity.findViewById(R.id.manageUsersButton).performClick();
+            Intent expectedIntent = ManageUsersActivity.manageUsersIntentFactory(activity);
+            Intent actualIntent = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
+            assertEquals(expectedIntent.getComponent(), actualIntent.getComponent());
+        }
+    }
+
+    @Test
+    public void testClickingManageGenres() {
+        try(ActivityController<AdminActivity> controller = Robolectric.buildActivity(AdminActivity.class)){
+            controller.setup();
+
+            AdminActivity activity = controller.get();
+            activity.findViewById(R.id.manageGenresButton).performClick();
+            Intent expectedIntent = ManageGenresActivity.manageGenresIntentFactory(activity);
+            Intent actualIntent = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
+            assertEquals(expectedIntent.getComponent(), actualIntent.getComponent());
+        }
+    }
+
+    @Test
+    public void testClickingAdminThings() {
+        try(ActivityController<AdminActivity> controller = Robolectric.buildActivity(AdminActivity.class)){
+            controller.setup();
+
+            AdminActivity activity = controller.get();
+            activity.findViewById(R.id.adminThingsButton).performClick();
+            Intent expectedIntent = AdminThingsActivity.adminThingsIntentFactory(activity);
+            Intent actualIntent = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
+            assertEquals(expectedIntent.getComponent(), actualIntent.getComponent());
+        }
+    }
+
+}

--- a/app/src/test/java/com/example/final_project/LoginActivityTest.java
+++ b/app/src/test/java/com/example/final_project/LoginActivityTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertNull;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.content.Intent;
+import android.util.Log;
 import android.widget.EditText;
 
 import org.junit.Test;
@@ -70,4 +71,23 @@ public class LoginActivityTest {
             assertNull(actual);
         }
     }
+
+    @Test
+    public void signingInWithValidCreds_LaunchesAdminActivity(){
+
+        try(ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class)){
+            controller.setup();
+             LoginActivity activity = controller.get();
+
+             EditText usernameField = activity.findViewById(R.id.usernameLoginEditText);
+
+             usernameField.setText("admin");
+
+             activity.findViewById(R.id.loginButton).performClick();
+             Intent expectedIntent = AdminActivity.adminIntentFactory(activity);
+             Intent actualIntent = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
+             assertEquals(expectedIntent.getComponent(), actualIntent.getComponent());
+        }
+    }
+
 }


### PR DESCRIPTION
## Description
[Issue](https://github.com/Katz100/Final-Project/issues/47)
- Implemented UnitTest for AdminActivity Intent factory from LoginActivityTest
- Implemented UnitTest for ManageUsers, ManageGenres, and AdminThings Intent factories from AdminActivityTest 
- Commented out a section of admin code in MainActivity and moved it to LoginActivity

## Steps for reviewer
- Step 1: Within AdminActivityTest, run and they should pass.
- Step 2: Change expectedIntent variable to a different class
- Step 3: Run the tests; they should fail.
- Step 4: Within LoginActivityTest, signingInWithValidCreds_LaunchesAdminActivity should be run, and it should pass the test.
- Step 5: Change usernameField.setText("admin"); to anything that does not have admin
- Step 6: Run the tests, it should fail
