### PR TITLE
Validate User Movie Rating

### DIFF
--- a/app/src/main/java/com/example/final_project/MainActivity.java
+++ b/app/src/main/java/com/example/final_project/MainActivity.java
@@ -70,9 +70,9 @@ public class MainActivity extends AppCompatActivity {
         watchListAdapter = new WatchListAdapter(this, initialWatchList);
         recyclerView.setAdapter(watchListAdapter);
 
-        watchListAdapter.setOnCheckedChangeListener((movie, isChecked) -> {
+        watchListAdapter.setOnCheckedChangeListener((movie, position, isChecked) -> {
             if (isChecked) {
-                showInputDialog(movie);
+                showInputDialog(movie, position);
             }
         });
 
@@ -125,7 +125,7 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    private void showInputDialog(UsersMovies movie) {
+    private void showInputDialog(UsersMovies movie, int position) {
         AlertDialog.Builder builder = new AlertDialog.Builder(MainActivity.this);
         builder.setTitle("Add rating for " + movie.getTitle());
 
@@ -145,6 +145,7 @@ public class MainActivity extends AppCompatActivity {
                     if (rating < 0.0 || rating > 5.0) {
                         input.setError("Rating must be between 0.0 and 5.0");
                         Toast.makeText(MainActivity.this, "Rating must be between 0.0 and 5.0", Toast.LENGTH_SHORT).show();
+                        watchListAdapter.setItemChecked(position, false);
                         return;
                     }
                     Log.d(TAG, "User entered rating: " + rating + " for movie: " + movie.getTitle());
@@ -160,6 +161,7 @@ public class MainActivity extends AppCompatActivity {
 
                 } catch (NumberFormatException e) {
                     Log.e(TAG, "Invalid rating format", e);
+                    watchListAdapter.setItemChecked(position, false);
                 }
             } else {
                 Log.w(TAG, "No rating entered");

--- a/app/src/main/java/com/example/final_project/MainActivity.java
+++ b/app/src/main/java/com/example/final_project/MainActivity.java
@@ -19,6 +19,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import android.view.View;
 import android.widget.EditText;
+import android.widget.Toast;
 
 import com.example.final_project.database.UserCompletedMovies;
 import com.example.final_project.database.UsersMovies;
@@ -141,6 +142,11 @@ public class MainActivity extends AppCompatActivity {
             if (!userInput.isEmpty()) {
                 try {
                     double rating = Double.parseDouble(userInput);
+                    if (rating < 0.0 || rating > 5.0) {
+                        input.setError("Rating must be between 0.0 and 5.0");
+                        Toast.makeText(MainActivity.this, "Rating must be between 0.0 and 5.0", Toast.LENGTH_SHORT).show();
+                        return;
+                    }
                     Log.d(TAG, "User entered rating: " + rating + " for movie: " + movie.getTitle());
                     UserWatchList userWatchList = new UserWatchList(
                             movie.getUserId(),
@@ -150,6 +156,7 @@ public class MainActivity extends AppCompatActivity {
                     );
                     movie.setCompleted(false);
                     viewModel.setRating(userWatchList);
+                    dialog.dismiss();
 
                 } catch (NumberFormatException e) {
                     Log.e(TAG, "Invalid rating format", e);

--- a/app/src/main/java/com/example/final_project/viewHolder/WatchListAdapter.java
+++ b/app/src/main/java/com/example/final_project/viewHolder/WatchListAdapter.java
@@ -20,10 +20,18 @@ public class WatchListAdapter extends RecyclerView.Adapter<WatchListAdapter.View
     private LayoutInflater mInflater;
 
     public interface OnCheckedChangeListener {
-        void onItemCheckedChanged(UsersMovies item, boolean isChecked);
+        void onItemCheckedChanged(UsersMovies item, int position, boolean isChecked);
     }
 
     private OnCheckedChangeListener checkedChangeListener;
+
+    // uncheck/recheck box if not within rating range
+    public void setItemChecked(int position, boolean checked) {
+        if (position < 0 || position >= mData.size()) return;
+        UsersMovies item = mData.get(position);
+        item.setCompleted(checked);
+        notifyItemChanged(position);
+    }
 
     public void setOnCheckedChangeListener(OnCheckedChangeListener listener) {
         this.checkedChangeListener = listener;
@@ -56,10 +64,11 @@ public class WatchListAdapter extends RecyclerView.Adapter<WatchListAdapter.View
         holder.checkBox.setChecked(item.isCompleted());
 
         holder.checkBox.setOnCheckedChangeListener((buttonView, isChecked) -> {
-            item.setCompleted(isChecked);
-            Log.d("WatchListAdapter", "Item " + item.getTitle() + " checked: " + isChecked);
             if (checkedChangeListener != null) {
-                checkedChangeListener.onItemCheckedChanged(item, isChecked);
+                int adapterPos = holder.getAdapterPosition();
+                if (adapterPos != RecyclerView.NO_POSITION) {
+                    checkedChangeListener.onItemCheckedChanged(item, adapterPos, isChecked);
+                }
             }
         });
     }


### PR DESCRIPTION
## Description
[Issue](https://github.com/Katz100/Final-Project/issues/81)
- Enforces ratings between 0.0 and 5.0. Shows a toast on invalid input and reverts the checkbox to unchecked.

## Steps for reviewer
- Run the app.
- Log in as a regular user.
- Mark a movie as watched (add one first if needed).
- Enter a rating outside the 0.0–5.0 range.
- Confirm a toast appears stating the rating must be between 0.0 and 5.0, and the checkbox is unchecked.
- Verify the app continues to function normally.