### PR TITLE
Promote/Demote users

### DIFF
--- a/app/src/main/java/com/example/final_project/AdminActivity.java
+++ b/app/src/main/java/com/example/final_project/AdminActivity.java
@@ -197,7 +197,7 @@ public class AdminActivity extends AppCompatActivity {
                         .setMessage("Are you sure you want to promote this user?") //change to show selected user
                         .setPositiveButton("Yes", (dialog, which) -> {
                             for (User user : selectedUsers) {
-                                viewModel.promoteUser(user.getUsername());
+                                viewModel.promoteUser(user);
                                 }
                             Toast.makeText(this,"User has been promoted", Toast.LENGTH_SHORT).show(); //change to show selected user
                             selectedUsers.clear();
@@ -219,7 +219,7 @@ public class AdminActivity extends AppCompatActivity {
                     .setMessage("Are you sure you want to demote this user?")
                     .setPositiveButton("Yes", (dialog, which) -> {
                         for (User user : selectedUsers) {
-                            viewModel.demoteUser(user.getUsername());
+                            viewModel.demoteUser(user);
                         }
                         Toast.makeText(this, "This user has been demoted", Toast.LENGTH_SHORT).show();
                         selectedUsers.clear();
@@ -232,11 +232,17 @@ public class AdminActivity extends AppCompatActivity {
     private void showDeleteUserDialog(){
         Button deleteUserButton = findViewById(R.id.deleteUserButton);
         deleteUserButton.setOnClickListener(v -> {
+            if (selectedUsers.isEmpty()) {
+                Toast.makeText(this, "No users selected", Toast.LENGTH_SHORT).show();
+                return;
+            }
             new AlertDialog.Builder(this)
                     .setTitle("Confirm Deletion")
                     .setMessage("Are you sure you want to delete this user?") //change to show selected user
                     .setPositiveButton("Yes", (dialog, which) -> {
-                        //call delete user method
+                        for (User user : selectedUsers) {
+                            viewModel.deleteUser(user);
+                        }
                         Toast.makeText(this, "This user has been deleted", Toast.LENGTH_SHORT).show(); //change to show selected user
                     })
                     .setNegativeButton("Cancel", null).show();
@@ -247,12 +253,18 @@ public class AdminActivity extends AppCompatActivity {
     private void showDeleteAdminDialog() {
         Button deleteButtonAdmin = findViewById(R.id.deleteButtonAdmin);
         deleteButtonAdmin.setOnClickListener(v -> {
+            if (selectedUsers.isEmpty()) {
+                Toast.makeText(this, "No users selected", Toast.LENGTH_SHORT).show();
+                return;
+            }
             new AlertDialog.Builder(this)
                     .setTitle("Confirm Deletion")
-                    .setMessage("Are you sure you want to delete this admin?") //change to show selected user
+                    .setMessage("Are you sure you want to delete this user?")
                     .setPositiveButton("Yes", (dialog, which) -> {
-                        //call delete user method
-                        Toast.makeText(this, "This admin has been deleted", Toast.LENGTH_SHORT).show(); //change to show selected user
+                        for (User user : selectedUsers) {
+                            viewModel.deleteUser(user);
+                        }
+                        Toast.makeText(this, "This user has been deleted", Toast.LENGTH_SHORT).show();
                     })
                     .setNegativeButton("Cancel", null).show();
         });

--- a/app/src/main/java/com/example/final_project/AdminActivity.java
+++ b/app/src/main/java/com/example/final_project/AdminActivity.java
@@ -25,6 +25,8 @@ import com.example.final_project.viewHolder.AdminListAdapter;
 import com.example.final_project.viewHolder.UserListAdapter;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 
 public class AdminActivity extends AppCompatActivity {
 
@@ -32,6 +34,8 @@ public class AdminActivity extends AppCompatActivity {
     UserListAdapter nonAdminListAdapter;
     AdminListAdapter adminListAdapter;
     private AdminDashboardListViewModel viewModel;
+    private final Set<User> selectedUsers = new HashSet<>();
+
     public static final String ADMIN_ACTIVITY_USERNAME_KEY = "com.example.final_project.AdminActivity.username";
 
     @Override
@@ -53,6 +57,14 @@ public class AdminActivity extends AppCompatActivity {
         recyclerViewAdmins.setLayoutManager(new LinearLayoutManager(this));
         adminListAdapter = new AdminListAdapter(this, adminList);
         recyclerViewAdmins.setAdapter(adminListAdapter);
+
+        nonAdminListAdapter.setOnCheckedChangeListener((user, isChecked) -> {
+            if (isChecked) {
+                selectedUsers.add(user);
+            } else {
+                selectedUsers.remove(user);
+            }
+        });
 
         //adds back button to action bar
         setSupportActionBar(binding.adminToolbar);
@@ -168,14 +180,22 @@ public class AdminActivity extends AppCompatActivity {
     private void showPromoteDialog(){
         Button promoteButton = findViewById(R.id.promoteUserButton);
         promoteButton.setOnClickListener(v -> {
+            if (selectedUsers.isEmpty()) {
+                Toast.makeText(this, "No users selected", Toast.LENGTH_SHORT).show();
+                return;
+            }
             new AlertDialog.Builder(this)
-                    .setTitle("Confirm Promotion")
-                    .setMessage("Are you sure you want to promote this user?") //change to show selected user
-                    .setPositiveButton("Yes", (dialog, which) -> {
-                        Toast.makeText(this, "This user has been promoted", Toast.LENGTH_SHORT).show(); //change to show selected user
-                    })
-                    .setNegativeButton("Cancel", null).show();
-        });
+                        .setTitle("Confirm Promotion")
+                        .setMessage("Are you sure you want to promote this user?") //change to show selected user
+                        .setPositiveButton("Yes", (dialog, which) -> {
+                            for (User user : selectedUsers) {
+                                viewModel.promoteUser(user.getUsername());
+                                }
+                            Toast.makeText(this,"User has been promoted", Toast.LENGTH_SHORT).show(); //change to show selected user
+                            selectedUsers.clear();
+                            })
+                        .setNegativeButton("Cancel", null).show();
+            });
 
     }
 
@@ -240,5 +260,6 @@ public class AdminActivity extends AppCompatActivity {
         intent.putExtra(ADMIN_ACTIVITY_USERNAME_KEY, username);
         return intent;
     }
+
 
 }

--- a/app/src/main/java/com/example/final_project/AdminActivity.java
+++ b/app/src/main/java/com/example/final_project/AdminActivity.java
@@ -55,7 +55,7 @@ public class AdminActivity extends AppCompatActivity {
 
         RecyclerView recyclerViewAdmins = findViewById(R.id.adminUserAdminRecyclerView);
         recyclerViewAdmins.setLayoutManager(new LinearLayoutManager(this));
-        adminListAdapter = new AdminListAdapter(this, adminList);
+        adminListAdapter = new AdminListAdapter(this, adminList, selectedUsers);
         recyclerViewAdmins.setAdapter(adminListAdapter);
 
         nonAdminListAdapter.setOnCheckedChangeListener((user, isChecked) -> {

--- a/app/src/main/java/com/example/final_project/AdminActivity.java
+++ b/app/src/main/java/com/example/final_project/AdminActivity.java
@@ -185,87 +185,78 @@ public class AdminActivity extends AppCompatActivity {
         alertBuilder.create().show();
     }
 
-    private void showPromoteDialog(){
-            if (selectedUsers.isEmpty()) {
-                Toast.makeText(this, "No users selected", Toast.LENGTH_SHORT).show();
-                return;
-            }
-            new AlertDialog.Builder(this)
-                        .setTitle("Confirm Promotion")
-                        .setMessage("Are you sure you want to promote this user?") //change to show selected user
-                        .setPositiveButton("Yes", (dialog, which) -> {
-                            for (User user : selectedUsers) {
-                                viewModel.promoteUser(user);
-                                }
-                            Toast.makeText(this,"User has been promoted", Toast.LENGTH_SHORT).show(); //change to show selected user
-                            selectedUsers.clear();
-                            })
-                        .setNegativeButton("Cancel", null).show();
-          
+    private void showPromoteDialog() {
+        if (selectedUsers.isEmpty()) {
+            Toast.makeText(this, "No users selected", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        new AlertDialog.Builder(this)
+                .setTitle("Confirm Promotion")
+                .setMessage("Are you sure you want to promote this user?") //change to show selected user
+                .setPositiveButton("Yes", (dialog, which) -> {
+                    for (User user : selectedUsers) {
+                        viewModel.promoteUser(user);
+                    }
+                    Toast.makeText(this, "User has been promoted", Toast.LENGTH_SHORT).show(); //change to show selected user
+                    selectedUsers.clear();
+                })
+                .setNegativeButton("Cancel", null).show();
+
 
     }
 
-    private void showDemoteDialog(){
-        Button demoteButton = findViewById(R.id.demoteAdminButton);
-        demoteButton.setOnClickListener(v -> {
-            if (selectedUsers.isEmpty()) {
-                Toast.makeText(this, "No users selected", Toast.LENGTH_SHORT).show();
-                return;
-            }
-            new AlertDialog.Builder(this)
-                    .setTitle("Confirm Demotion")
-                    .setMessage("Are you sure you want to demote this user?")
-                    .setPositiveButton("Yes", (dialog, which) -> {
-                        for (User user : selectedUsers) {
-                            viewModel.demoteUser(user);
-                        }
-                        Toast.makeText(this, "This user has been demoted", Toast.LENGTH_SHORT).show();
-                        selectedUsers.clear();
-                    })
-                    .setNegativeButton("Cancel", null).show();
-        });
-
+    private void showDemoteDialog() {
+        if (selectedUsers.isEmpty()) {
+            Toast.makeText(this, "No users selected", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        new AlertDialog.Builder(this)
+                .setTitle("Confirm Demotion")
+                .setMessage("Are you sure you want to demote this user?")
+                .setPositiveButton("Yes", (dialog, which) -> {
+                    for (User user : selectedUsers) {
+                        viewModel.demoteUser(user);
+                    }
+                    Toast.makeText(this, "This user has been demoted", Toast.LENGTH_SHORT).show();
+                    selectedUsers.clear();
+                })
+                .setNegativeButton("Cancel", null).show();
     }
 
-    private void showDeleteUserDialog(){
-        Button deleteUserButton = findViewById(R.id.deleteUserButton);
-        deleteUserButton.setOnClickListener(v -> {
-            if (selectedUsers.isEmpty()) {
-                Toast.makeText(this, "No users selected", Toast.LENGTH_SHORT).show();
-                return;
-            }
-            new AlertDialog.Builder(this)
-                    .setTitle("Confirm Deletion")
-                    .setMessage("Are you sure you want to delete this user?") //change to show selected user
-                    .setPositiveButton("Yes", (dialog, which) -> {
-                        for (User user : selectedUsers) {
-                            viewModel.deleteUser(user);
-                        }
-                        Toast.makeText(this, "This user has been deleted", Toast.LENGTH_SHORT).show(); //change to show selected user
-                    })
-                    .setNegativeButton("Cancel", null).show();
-        });
+
+    private void showDeleteUserDialog() {
+        if (selectedUsers.isEmpty()) {
+            Toast.makeText(this, "No users selected", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        new AlertDialog.Builder(this)
+                .setTitle("Confirm Deletion")
+                .setMessage("Are you sure you want to delete this user?") //change to show selected user
+                .setPositiveButton("Yes", (dialog, which) -> {
+                    for (User user : selectedUsers) {
+                        viewModel.deleteUser(user);
+                    }
+                    Toast.makeText(this, "This user has been deleted", Toast.LENGTH_SHORT).show(); //change to show selected user
+                })
+                .setNegativeButton("Cancel", null).show();
 
     }
 
     private void showDeleteAdminDialog() {
-        Button deleteButtonAdmin = findViewById(R.id.deleteButtonAdmin);
-        deleteButtonAdmin.setOnClickListener(v -> {
-            if (selectedUsers.isEmpty()) {
-                Toast.makeText(this, "No users selected", Toast.LENGTH_SHORT).show();
-                return;
-            }
-            new AlertDialog.Builder(this)
-                    .setTitle("Confirm Deletion")
-                    .setMessage("Are you sure you want to delete this user?")
-                    .setPositiveButton("Yes", (dialog, which) -> {
-                        for (User user : selectedUsers) {
-                            viewModel.deleteUser(user);
-                        }
-                        Toast.makeText(this, "This user has been deleted", Toast.LENGTH_SHORT).show();
-                    })
-                    .setNegativeButton("Cancel", null).show();
-        });
+        if (selectedUsers.isEmpty()) {
+            Toast.makeText(this, "No users selected", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        new AlertDialog.Builder(this)
+                .setTitle("Confirm Deletion")
+                .setMessage("Are you sure you want to delete this user?")
+                .setPositiveButton("Yes", (dialog, which) -> {
+                    for (User user : selectedUsers) {
+                        viewModel.deleteUser(user);
+                    }
+                    Toast.makeText(this, "This user has been deleted", Toast.LENGTH_SHORT).show();
+                })
+                .setNegativeButton("Cancel", null).show();
     }
 
     private void logout(){

--- a/app/src/main/java/com/example/final_project/AdminActivity.java
+++ b/app/src/main/java/com/example/final_project/AdminActivity.java
@@ -66,6 +66,14 @@ public class AdminActivity extends AppCompatActivity {
             }
         });
 
+        adminListAdapter.setOnCheckedChangeListener((user, isChecked) -> {
+            if (isChecked) {
+                selectedUsers.add(user);
+            } else {
+                selectedUsers.remove(user);
+            }
+        });
+
         //adds back button to action bar
         setSupportActionBar(binding.adminToolbar);
         if (getSupportActionBar() != null) {
@@ -202,11 +210,19 @@ public class AdminActivity extends AppCompatActivity {
     private void showDemoteDialog(){
         Button demoteButton = findViewById(R.id.demoteAdminButton);
         demoteButton.setOnClickListener(v -> {
+            if (selectedUsers.isEmpty()) {
+                Toast.makeText(this, "No users selected", Toast.LENGTH_SHORT).show();
+                return;
+            }
             new AlertDialog.Builder(this)
                     .setTitle("Confirm Demotion")
-                    .setMessage("Are you sure you want to demote this user?") //change to show selected user
+                    .setMessage("Are you sure you want to demote this user?")
                     .setPositiveButton("Yes", (dialog, which) -> {
-                        Toast.makeText(this, "This user has been promoted", Toast.LENGTH_SHORT).show(); //change to show selected user
+                        for (User user : selectedUsers) {
+                            viewModel.demoteUser(user.getUsername());
+                        }
+                        Toast.makeText(this, "This user has been demoted", Toast.LENGTH_SHORT).show();
+                        selectedUsers.clear();
                     })
                     .setNegativeButton("Cancel", null).show();
         });

--- a/app/src/main/java/com/example/final_project/AdminActivity.java
+++ b/app/src/main/java/com/example/final_project/AdminActivity.java
@@ -8,6 +8,8 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.widget.Button;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
@@ -30,6 +32,18 @@ public class AdminActivity extends AppCompatActivity {
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
+
+        // Set up button listeners
+        Button promoteButton = findViewById(R.id.promoteUserButton);
+        Button deleteUserButton = findViewById(R.id.deleteUserButton);
+        Button demoteButton = findViewById(R.id.demoteAdminButton);
+        Button deleteButtonAdmin = findViewById((R.id.deleteButtonAdmin));
+
+        promoteButton.setOnClickListener(v -> showPromoteDialog());
+        deleteUserButton.setOnClickListener(v -> showDeleteUserDialog());
+
+        demoteButton.setOnClickListener(v -> showDemoteDialog());
+        deleteButtonAdmin.setOnClickListener(v -> showDeleteAdminDialog());
 
     }
 
@@ -100,6 +114,63 @@ public class AdminActivity extends AppCompatActivity {
             }
         });
         alertBuilder.create().show();
+    }
+
+    private void showPromoteDialog(){
+        Button promoteButton = findViewById(R.id.promoteUserButton);
+        promoteButton.setOnClickListener(v -> {
+            new AlertDialog.Builder(this)
+                    .setTitle("Confirm Promotion")
+                    .setMessage("Are you sure you want to promote this user?") //change to show selected user
+                    .setPositiveButton("Yes", (dialog, which) -> {
+                        Toast.makeText(this, "This user has been promoted", Toast.LENGTH_SHORT).show(); //change to show selected user
+                    })
+                    .setNegativeButton("Cancel", null).show();
+        });
+
+    }
+
+    private void showDemoteDialog(){
+        Button demoteButton = findViewById(R.id.demoteAdminButton);
+        demoteButton.setOnClickListener(v -> {
+            new AlertDialog.Builder(this)
+                    .setTitle("Confirm Demotion")
+                    .setMessage("Are you sure you want to demote this user?") //change to show selected user
+                    .setPositiveButton("Yes", (dialog, which) -> {
+                        Toast.makeText(this, "This user has been promoted", Toast.LENGTH_SHORT).show(); //change to show selected user
+                    })
+                    .setNegativeButton("Cancel", null).show();
+        });
+
+    }
+
+    private void showDeleteUserDialog(){
+        Button deleteUserButton = findViewById(R.id.deleteUserButton);
+        deleteUserButton.setOnClickListener(v -> {
+            new AlertDialog.Builder(this)
+                    .setTitle("Confirm Deletion")
+                    .setMessage("Are you sure you want to delete this user?") //change to show selected user
+                    .setPositiveButton("Yes", (dialog, which) -> {
+                        //call delete user method
+                        Toast.makeText(this, "This user has been deleted", Toast.LENGTH_SHORT).show(); //change to show selected user
+                    })
+                    .setNegativeButton("Cancel", null).show();
+        });
+
+    }
+
+    private void showDeleteAdminDialog() {
+        Button deleteButtonAdmin = findViewById(R.id.deleteButtonAdmin);
+        deleteButtonAdmin.setOnClickListener(v -> {
+            new AlertDialog.Builder(this)
+                    .setTitle("Confirm Deletion")
+                    .setMessage("Are you sure you want to delete this admin?") //change to show selected user
+                    .setPositiveButton("Yes", (dialog, which) -> {
+                        //call delete user method
+                        Toast.makeText(this, "This admin has been deleted", Toast.LENGTH_SHORT).show(); //change to show selected user
+                    })
+                    .setNegativeButton("Cancel", null).show();
+        });
     }
 
     private void logout(){

--- a/app/src/main/java/com/example/final_project/database/MovieWatchlistDatabase.java
+++ b/app/src/main/java/com/example/final_project/database/MovieWatchlistDatabase.java
@@ -63,8 +63,13 @@ public abstract class MovieWatchlistDatabase extends RoomDatabase {
                 User admin = new User("admin1", "admin1", true);
                 admin.setAdmin(true);
                 dao.insert(admin);
+                User admin2 = new User("admin2", "admin2", true);
+                admin.setAdmin(true);
+                dao.insert(admin2);
                 User testUser1 = new User("testuser1", "testuser1", false);
                 dao.insert(testUser1);
+                User testUser2 = new User("testuser2", "testuser2", false);
+                dao.insert(testUser2);
 
                 for (int i = 0; i < 10; i++) {
                     movieDAO.insert(new Movie("Movie" + i, "Comedy"));

--- a/app/src/main/java/com/example/final_project/database/MovieWatchlistDatabase.java
+++ b/app/src/main/java/com/example/final_project/database/MovieWatchlistDatabase.java
@@ -64,7 +64,7 @@ public abstract class MovieWatchlistDatabase extends RoomDatabase {
                 admin.setAdmin(true);
                 dao.insert(admin);
                 User admin2 = new User("admin2", "admin2", true);
-                admin.setAdmin(true);
+                admin2.setAdmin(true);
                 dao.insert(admin2);
                 User testUser1 = new User("testuser1", "testuser1", false);
                 dao.insert(testUser1);

--- a/app/src/main/java/com/example/final_project/database/UserDAO.java
+++ b/app/src/main/java/com/example/final_project/database/UserDAO.java
@@ -28,6 +28,14 @@ public interface UserDAO {
 
     @Update
     int update(User user);
+
+    @Query("UPDATE user_table SET isAdmin = 1 WHERE username == :username")
+    void promoteUser(String username);
+
+    @Query("UPDATE user_table SET isAdmin = 0 WHERE username == :username")
+    void demoteUser(String username);
+
+
 /*
     @Query("SELECT * FROM " + MovieWatchListDatabase.USER_TABLE + " ORDER BY username")
     LiveData<List<User>> getAllUsers();

--- a/app/src/main/java/com/example/final_project/database/UserListRepository.java
+++ b/app/src/main/java/com/example/final_project/database/UserListRepository.java
@@ -36,5 +36,23 @@ public class UserListRepository {
     public LiveData<List<User>> getAllUsers() {
         return userDAO.getAllUsers();
     }
+    public void promoteUser(String username) {
+        MovieWatchlistDatabase.databaseWriteExecutor.execute(() -> {
+            userDAO.promoteUser(username);
+        });
+    }
+
+    public void demoteUser(String username) {
+        MovieWatchlistDatabase.databaseWriteExecutor.execute(() -> {
+            userDAO.demoteUser(username);
+        });
+    }
+
+    public void deleteUser(User user) {
+        MovieWatchlistDatabase.databaseWriteExecutor.execute(() -> {
+            userDAO.delete(user);
+        });
+    }
+
 
 }

--- a/app/src/main/java/com/example/final_project/database/UserListRepository.java
+++ b/app/src/main/java/com/example/final_project/database/UserListRepository.java
@@ -36,15 +36,15 @@ public class UserListRepository {
     public LiveData<List<User>> getAllUsers() {
         return userDAO.getAllUsers();
     }
-    public void promoteUser(String username) {
+    public void promoteUser(User user) {
         MovieWatchlistDatabase.databaseWriteExecutor.execute(() -> {
-            userDAO.promoteUser(username);
+            userDAO.promoteUser(user.getUsername());
         });
     }
 
-    public void demoteUser(String username) {
+    public void demoteUser(User user) {
         MovieWatchlistDatabase.databaseWriteExecutor.execute(() -> {
-            userDAO.demoteUser(username);
+            userDAO.demoteUser(user.getUsername());
         });
     }
 

--- a/app/src/main/java/com/example/final_project/viewHolder/AdminDashboardListViewModel.java
+++ b/app/src/main/java/com/example/final_project/viewHolder/AdminDashboardListViewModel.java
@@ -52,12 +52,12 @@ public class AdminDashboardListViewModel extends AndroidViewModel {
     public void getAllNonAdmins() {
         userListRepository.getAllNonAdmins();
     }
-    public void promoteUser(String username) {
-        userListRepository.promoteUser(username);
+    public void promoteUser(User user) {
+        userListRepository.promoteUser(user);
     }
 
-    public void demoteUser(String username) {
-        userListRepository.demoteUser(username);
+    public void demoteUser(User user) {
+        userListRepository.demoteUser(user);
     }
 
     public void deleteUser(User user) {

--- a/app/src/main/java/com/example/final_project/viewHolder/AdminDashboardListViewModel.java
+++ b/app/src/main/java/com/example/final_project/viewHolder/AdminDashboardListViewModel.java
@@ -52,4 +52,16 @@ public class AdminDashboardListViewModel extends AndroidViewModel {
     public void getAllNonAdmins() {
         userListRepository.getAllNonAdmins();
     }
+    public void promoteUser(String username) {
+        userListRepository.promoteUser(username);
+    }
+
+    public void demoteUser(String username) {
+        userListRepository.demoteUser(username);
+    }
+
+    public void deleteUser(User user) {
+        userListRepository.deleteUser(user);
+    }
+
 }

--- a/app/src/main/java/com/example/final_project/viewHolder/AdminListAdapter.java
+++ b/app/src/main/java/com/example/final_project/viewHolder/AdminListAdapter.java
@@ -25,6 +25,10 @@ public class AdminListAdapter extends RecyclerView.Adapter<AdminListAdapter.View
         void onItemCheckedChanged(User item, boolean isChecked);
     }
 
+    public void setOnCheckedChangeListener(OnCheckedChangeListener listener) {
+        this.checkedChangeListener = listener;
+    }
+
     private AdminListAdapter.OnCheckedChangeListener checkedChangeListener;
 
     public AdminListAdapter(Context context, List<User> data) {
@@ -51,16 +55,16 @@ public class AdminListAdapter extends RecyclerView.Adapter<AdminListAdapter.View
         holder.isAdminTextView.setText(item.isAdmin()? "Admin: Yes" : "Admin: No");
 
         holder.checkBox.setOnCheckedChangeListener(null);
-        /* will need to be changed to current selected user
+        //will need to be changed to current selected user
         holder.checkBox.setChecked(item.isAdmin());
 
         holder.checkBox.setOnCheckedChangeListener((buttonView, isChecked) -> {
-            item.setCompleted(isChecked);
-            Log.d("WatchListAdapter", "Item " + item.getTitle() + " checked: " + isChecked);
+            item.setAdmin(isChecked);
+            Log.d("WatchListAdapter", "User " + item.getUsername() + " checked: " + isChecked);
             if (checkedChangeListener != null) {
                 checkedChangeListener.onItemCheckedChanged(item, isChecked);
             }
-        });*/
+        });
     }
 
     @Override

--- a/app/src/main/java/com/example/final_project/viewHolder/AdminListAdapter.java
+++ b/app/src/main/java/com/example/final_project/viewHolder/AdminListAdapter.java
@@ -15,11 +15,15 @@ import com.example.final_project.R;
 import com.example.final_project.database.entities.User;
 
 import java.util.List;
+import java.util.Set;
 
 public class AdminListAdapter extends RecyclerView.Adapter<AdminListAdapter.ViewHolder> {
 
     private List<User> mData;
     private LayoutInflater mInflater;
+    private Set<User> selectedUsers;
+
+
 
     public interface OnCheckedChangeListener {
         void onItemCheckedChanged(User item, boolean isChecked);
@@ -31,9 +35,11 @@ public class AdminListAdapter extends RecyclerView.Adapter<AdminListAdapter.View
 
     private AdminListAdapter.OnCheckedChangeListener checkedChangeListener;
 
-    public AdminListAdapter(Context context, List<User> data) {
+    public AdminListAdapter(Context context, List<User> data, Set<User> selectedUsers) {
         this.mInflater = LayoutInflater.from(context);
         this.mData = data;
+        this.selectedUsers = selectedUsers;
+
     }
 
     public void updateUsers(List<User> newList) {
@@ -55,8 +61,7 @@ public class AdminListAdapter extends RecyclerView.Adapter<AdminListAdapter.View
         holder.isAdminTextView.setText(item.isAdmin()? "Admin: Yes" : "Admin: No");
 
         holder.checkBox.setOnCheckedChangeListener(null);
-        //will need to be changed to current selected user
-        holder.checkBox.setChecked(item.isAdmin());
+        holder.checkBox.setChecked(selectedUsers.contains(item));
 
         holder.checkBox.setOnCheckedChangeListener((buttonView, isChecked) -> {
             item.setAdmin(isChecked);

--- a/app/src/main/java/com/example/final_project/viewHolder/UserListAdapter.java
+++ b/app/src/main/java/com/example/final_project/viewHolder/UserListAdapter.java
@@ -24,6 +24,9 @@ public class UserListAdapter extends RecyclerView.Adapter<UserListAdapter.ViewHo
     public interface OnCheckedChangeListener {
         void onItemCheckedChanged(User item, boolean isChecked);
     }
+    public void setOnCheckedChangeListener(UserListAdapter.OnCheckedChangeListener listener) {
+        this.checkedChangeListener = listener;
+    }
 
     private UserListAdapter.OnCheckedChangeListener checkedChangeListener;
 
@@ -51,16 +54,16 @@ public class UserListAdapter extends RecyclerView.Adapter<UserListAdapter.ViewHo
         holder.isAdminTextView.setText(item.isAdmin()? "Admin: Yes" : "Admin: No");
 
         holder.checkBox.setOnCheckedChangeListener(null);
-        /* will need to be changed to current selected user
+        // will need to be changed to current selected user
         holder.checkBox.setChecked(item.isAdmin());
 
         holder.checkBox.setOnCheckedChangeListener((buttonView, isChecked) -> {
-            item.setCompleted(isChecked);
-            Log.d("WatchListAdapter", "Item " + item.getTitle() + " checked: " + isChecked);
+            item.setAdmin(isChecked);
+            Log.d("WatchListAdapter", "Item " + item.getUsername() + " checked: " + isChecked);
             if (checkedChangeListener != null) {
                 checkedChangeListener.onItemCheckedChanged(item, isChecked);
             }
-        });*/
+        });
     }
 
     @Override

--- a/app/src/test/java/com/example/final_project/database/AdminActivityTest.java
+++ b/app/src/test/java/com/example/final_project/database/AdminActivityTest.java
@@ -1,0 +1,18 @@
+package com.example.final_project.database;
+
+import org.junit.Test;
+
+public class AdminActivityTest {
+    @Test
+    public void testPromoteButtonUpdatesUser() {
+        // Launch activity, click promote button, verify user is promoted
+    }
+
+    @Test
+    public void testDemoteButtonUpdatesUser() {
+        // Launch activity, click demote button, verify user is promoted
+    }
+
+
+
+}

--- a/app/src/test/java/com/example/final_project/database/AdminActivityTest.java
+++ b/app/src/test/java/com/example/final_project/database/AdminActivityTest.java
@@ -1,11 +1,13 @@
 package com.example.final_project.database;
 
+import com.example.final_project.database.entities.User;
+
 import org.junit.Test;
 
 public class AdminActivityTest {
     @Test
-    public void testPromoteButtonUpdatesUser() {
-        // Launch activity, click promote button, verify user is promoted
+    public void testPromote() {
+        // Launch activity, click demote button, verify user is promoted
     }
 
     @Test

--- a/app/src/test/java/com/example/final_project/database/UserDAOTest.java
+++ b/app/src/test/java/com/example/final_project/database/UserDAOTest.java
@@ -1,8 +1,10 @@
 package com.example.final_project.database;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
 
@@ -94,5 +96,24 @@ public class UserDAOTest {
         assertNull(user1);
         assertNull(user2);
     }
+
+    @Test
+    public void testPromoteUser() {
+        User user = new User("user1", "user1", false);
+        userDao.insert(user);
+        userDao.promoteUser(user.getUsername());
+        User updatedUser = userDao.getUserByUserName(user.getUsername());
+        assertTrue(updatedUser.isAdmin());
+    }
+
+    @Test
+    public void testDemoteUser() {
+        User user = new User("user1", "user1", false);
+        userDao.insert(user);
+        userDao.demoteUser(user.getUsername());
+        User updatedUser = userDao.getUserByUserName(user.getUsername());
+        assertFalse(updatedUser.isAdmin());
+    }
+
 
 }


### PR DESCRIPTION
[## Description
Issue #85 (https://github.com/Katz100/Final-Project/issues/85)
Issue #88 (https://github.com/Katz100/Final-Project/issues/88)
- Added Promote and Demote methods
- Added confirmation dialogs before each action
- Added more users for testing purposes (1 regular, 1 admin)
- Shows a Toast message after the user confirms
- Promote, Demote, and both Delete buttons should update users in the DB
- Users that are promoted should move to Admin User section
- Users that are Demoted should move to Regular User section
- Users that are deleted are removed from the page

## Steps for reviewer
- Sign in as admin1 (username/password)
- Ensure all buttons work as intended
- Log back in as a user who was promoted/demoted/deleted
- Ensure that the correct activity is being displayed
