### PR TITLE
clears input fields after successful sign up

### DIFF
--- a/app/src/main/java/com/example/final_project/SignUpActivity.java
+++ b/app/src/main/java/com/example/final_project/SignUpActivity.java
@@ -57,6 +57,12 @@ public class SignUpActivity extends AppCompatActivity {
                 Log.i(TAG, "User is null, creating new user");
                 User newUser = new User(username, password, false);
                 viewModel.insertUser(newUser);
+
+                // clear input fields after successful sign up
+                usernameEditText.setText("");
+                passwordEditText.setText("");
+                confirmPasswordEditText.setText("");
+
                 Toast.makeText(this, "Welcome, " + username + "!", Toast.LENGTH_SHORT).show();
                 Intent intent = MainActivity.mainIntentFactory(this, username);
                 startActivity(intent);


### PR DESCRIPTION
## Description
[Issue](https://github.com/Katz100/Final-Project/issues/91)
- Fixed Sign Up form so username, password, and confirm password fields clear after a successful sign-up
- When testing, please return to the Sign Up screen using the Android emulator back button (circled in screenshot)
<img width="505" height="173" alt="image" src="https://github.com/user-attachments/assets/a5b23a25-dc65-4d0a-8242-48138fb0751e" />


## Steps for reviewer
- Open the app and go to the Sign Up screen
- Enter valid username, password, and confirm password, then tap "SIGN UP!"
- Press the emulator’s back button
- Verify that all three fields are cleared
